### PR TITLE
Add themeColor option to metadata

### DIFF
--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -34,13 +34,15 @@ export const updateMetadata = ({
   description,
   url,
   image,
-  imageAlt
+  imageAlt,
+  themeColor
 }: {
   title?: string,
   description?: string,
   url?: string,
   image?: string,
-  imageAlt?: string
+  imageAlt?: string,
+  themeColor?: string
 }) => {
   if (title) {
     document.title = title;
@@ -58,6 +60,10 @@ export const updateMetadata = ({
 
   if (imageAlt) {
     _setMeta('property', 'og:image:alt', imageAlt);
+  }
+
+  if (themeColor) {
+    _setMeta('name', 'theme-color', themeColor);
   }
 
   url = url || window.location.href;

--- a/test/metadata.html
+++ b/test/metadata.html
@@ -56,6 +56,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(getMetaContent('property', 'og:url'), window.location.href);
         });
 
+        test('update themColor', () => {
+          const themeColor = 'SOME_THEME_COLOR';
+          updateMetadata({themeColor});
+          assert.equal(getMetaContent('name', 'theme-color'), themeColor);
+          assert.equal(getMetaContent('property', 'og:url'), window.location.href);
+        });
+
         test('update url', () => {
           const url = 'SOME_URL';
           updateMetadata({url});


### PR DESCRIPTION
Option to update the `theme-color` meta tag.

`<meta name="theme-color" content="#ffffff">`

~~Just check https://github.com/Polymer/pwa-helpers/commit/66878a75d363e913edcedf6719e79149b4f66e98. When https://github.com/Polymer/pwa-helpers/pull/47 is merged, I can rebase it to master.~~