### PR TITLE
Add twitterCard option to metadata

### DIFF
--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -34,13 +34,15 @@ export const updateMetadata = ({
   description,
   url,
   image,
-  imageAlt
+  imageAlt,
+  twitterCard
 }: {
   title?: string,
   description?: string,
   url?: string,
   image?: string,
-  imageAlt?: string
+  imageAlt?: string,
+  twitterCard?: string
 }) => {
   if (title) {
     document.title = title;
@@ -58,6 +60,10 @@ export const updateMetadata = ({
 
   if (imageAlt) {
     _setMeta('property', 'og:image:alt', imageAlt);
+  }
+
+  if (twitterCard) {
+    _setMeta('name', 'twitter:card', twitterCard);
   }
 
   url = url || window.location.href;

--- a/test/metadata.html
+++ b/test/metadata.html
@@ -56,6 +56,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(getMetaContent('property', 'og:url'), window.location.href);
         });
 
+        test('update twitterCard', () => {
+          const twitterCard = 'SOME_TWITTER_CARD';
+          updateMetadata({twitterCard});
+          assert.equal(getMetaContent('name', 'twitter:card'), twitterCard);
+          assert.equal(getMetaContent('property', 'og:url'), window.location.href);
+        });
+
         test('update url', () => {
           const url = 'SOME_URL';
           updateMetadata({url});


### PR DESCRIPTION
Option to update the `theme-color` meta tag.

`<meta name="twitter-card" content="summary">`

Reference: https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary

~~Just check https://github.com/Polymer/pwa-helpers/commit/a4b56fd048cac57931e1aa7c76524687c502af9a. When https://github.com/Polymer/pwa-helpers/pull/47 is merged, I can rebase it to master.~~