### PR TITLE
Add image width & height options to metadata

### DIFF
--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -34,13 +34,17 @@ export const updateMetadata = ({
   description,
   url,
   image,
-  imageAlt
+  imageAlt,
+  imageWidth,
+  imageHeight
 }: {
   title?: string,
   description?: string,
   url?: string,
   image?: string,
-  imageAlt?: string
+  imageAlt?: string,
+  imageWidth?: string,
+  imageHeight?: string
 }) => {
   if (title) {
     document.title = title;
@@ -58,6 +62,14 @@ export const updateMetadata = ({
 
   if (imageAlt) {
     _setMeta('property', 'og:image:alt', imageAlt);
+  }
+
+  if (imageWidth) {
+    _setMeta('property', 'og:image:width', imageWidth);
+  }
+
+  if (imageHeight) {
+    _setMeta('property', 'og:image:height', imageHeight);
   }
 
   url = url || window.location.href;

--- a/test/metadata.html
+++ b/test/metadata.html
@@ -56,6 +56,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(getMetaContent('property', 'og:url'), window.location.href);
         });
 
+        test('update imageWidth', () => {
+          const imageWidth = 'SOME_IMAGE_WIDTH';
+          updateMetadata({imageWidth});
+          assert.equal(getMetaContent('property', 'og:image:width'), imageWidth);
+          assert.equal(getMetaContent('property', 'og:url'), window.location.href);
+        });
+
+        test('update imageHeight', () => {
+          const imageHeight = 'SOME_IMAGE_HEIGHT';
+          updateMetadata({imageHeight});
+          assert.equal(getMetaContent('property', 'og:image:height'), imageHeight);
+          assert.equal(getMetaContent('property', 'og:url'), window.location.href);
+        });
+
         test('update url', () => {
           const url = 'SOME_URL';
           updateMetadata({url});


### PR DESCRIPTION
Recommended by Facebook:

> **2. Use `og:image:width` and `og:image:height` Open Graph tags**
> 
> Using these tags will specify the image dimensions to the crawler so that it can render the image immediately without having to asynchronously download and process it.

Reference: https://developers.facebook.com/docs/sharing/best-practices/